### PR TITLE
Use always \015\012 as CRLF (\n is not equal to CRLF here under Win32 

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -161,7 +161,7 @@ is_deeply(
   "ignore __END__",
 );
 
-my $crlf = $^O eq 'MSWin32' ? "\n" : "\r\n";
+my $crlf = "\015\012";
 
 is_deeply(
   WindowsNewlines->local_section_data,


### PR DESCRIPTION
because of binmode dh, ':raw' at https://github.com/charsbar/Data-Section/blob/master/lib/Data/Section.pm#L199 )
