### PR TITLE
add :bytes to binmode dh, :raw as well

### DIFF
--- a/lib/Data/Section.pm
+++ b/lib/Data/Section.pm
@@ -196,7 +196,7 @@ sub _mk_reader_group {
 
     my $dh = do { no strict 'refs'; \*{"$pkg\::DATA"} }; ## no critic Strict
     return $stash{ $pkg } unless defined fileno *$dh;
-    binmode( $dh, ":raw" );
+    binmode( $dh, ":raw :bytes" );
 
     my ($current, $current_line);
     if ($arg->{default_name}) {


### PR DESCRIPTION
though perldoc -f binmode says :raw marks the data as bytes.
Confirmed this worked under ActivePerl 5.16.3 and Strawberry Perl 5.16.1 at hand (and will see for other versions of perl later).
