### PR TITLE
Unix line-ending whatever the platform together with UTF-8 or encoding defaults

### DIFF
--- a/lib/Data/Section.pm
+++ b/lib/Data/Section.pm
@@ -196,7 +196,7 @@ sub _mk_reader_group {
 
     my $dh = do { no strict 'refs'; \*{"$pkg\::DATA"} }; ## no critic Strict
     return $stash{ $pkg } unless defined fileno *$dh;
-    binmode( $dh, ":raw" );
+    binmode( $dh, ":perlio");
 
     my ($current, $current_line);
     if ($arg->{default_name}) {

--- a/t/basic.t
+++ b/t/basic.t
@@ -161,11 +161,9 @@ is_deeply(
   "ignore __END__",
 );
 
-my $crlf = "\015\012";
-
 is_deeply(
   WindowsNewlines->local_section_data,
-  { n => \"foo$crlf" },
+  { n => \"foo\n" },
   "windows newlines work",
 );
 


### PR DESCRIPTION
Issue #5: 0.200003 on Windows
