### PR TITLE
perl below v14 on win32 converts newlines before they reach DATA

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -161,12 +161,17 @@ is_deeply(
   "ignore __END__",
 );
 
-my $crlf = "\015\012";
+SKIP: {
+  skip "perl below v14 on win32 converts newlines before they reach DATA", 1
+    if $^O eq 'MSWin32' and $] < 5.014;
 
-is_deeply(
-  WindowsNewlines->local_section_data,
-  { n => \"foo$crlf" },
-  "windows newlines work",
-);
+  my $crlf = "\015\012";
+
+  is_deeply(
+    WindowsNewlines->local_section_data,
+    { n => \"foo$crlf" },
+    "windows newlines work",
+  );
+}
 
 done_testing;


### PR DESCRIPTION
This makes it impossible to read windows newlines in DATA segments.

Since this happens on the C level, there is no way to resolve this without patching perl, and as such the only sane resolution i can think of is to skip the test on windows if the perl version is too low.

I'm not too sure if the version comparison is what you'd like, it was just the most reliable thing i could think of. Feel free to munge however you like.
