### PR TITLE
allow roles as well as class based "inheritance"

### DIFF
--- a/lib/Data/Section.pm
+++ b/lib/Data/Section.pm
@@ -248,7 +248,7 @@ sub _mk_reader_group {
     my %merged;
     for my $class (@{ mro::get_linear_isa($pkg) }) {
       # in case of c3 + non-$base item showing up
-      next unless $class->isa($base);
+      next unless $class->DOES($base);
       my $sec_data = $class->$lsd;
 
       # checking for truth is okay, since things must be undef or a ref


### PR DESCRIPTION
I'd like to use `Data::Section` in a (`Moo`) role, but it doesn't recognize that sort of relationship.  This (tiny!) patch tries to remedy it.

Here's some test code which works with the suggested fix:
```
package DataSection;

use Moo::Role;
use Data::Section -setup;

package try;

use Moo;
with 'DataSection';

has foo => ( is => 'ro' );

sub BUILD {  print ${ $_[0]->section_data( 'config' ) } }

1;
__DATA__
__[ config ]__
Stuff & Nonsense
```
and the test:
```
% perl  -Mtry -e 'try->new'
Stuff & Nonsense
```
I'd like to add a test which natively constructs a role relationship (i.e. doesn't use Moo), but unfortunately I don't understand the magic by which UNIVERSAL::DOES identifies roles, so can't craft one.