### PR TITLE
documentation fix: use as class method

### DIFF
--- a/lib/Data/Section.pm
+++ b/lib/Data/Section.pm
@@ -18,7 +18,7 @@ use Sub::Exporter 0.979 -setup => {
   sub quit {
     my ($class, $angry, %arg) = @_;
 
-    my $template = $self->section_data(
+    my $template = $class->section_data(
       ($angry ? "angry_" : "professional_") . "letter"
     );
 


### PR DESCRIPTION
documentation will compile as is, but if you add use strict
it will fail.